### PR TITLE
feat: `io.cloudquery.scalar.Bool`

### DIFF
--- a/lib/src/main/java/io/cloudquery/scalar/Bool.java
+++ b/lib/src/main/java/io/cloudquery/scalar/Bool.java
@@ -1,0 +1,88 @@
+package io.cloudquery.scalar;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+public class Bool implements Scalar {
+    protected boolean value;
+    protected boolean valid;
+
+    public Bool() {
+    }
+
+    public Bool(Object value) throws ValidationException {
+        this.set(value);
+    }
+
+    @Override
+    public String toString() {
+        if (this.valid) {
+            return Boolean.toString(this.value);
+        }
+        return NULL_VALUE_STRING;
+    }
+
+    @Override
+    public boolean isValid() {
+        return this.valid;
+    }
+
+    @Override
+    public ArrowType dataType() {
+        return ArrowType.Bool.INSTANCE;
+    }
+
+    @Override
+    public void set(Object value) throws ValidationException {
+        if (value == null) {
+            this.valid = false;
+            this.value = false;
+            return;
+        }
+
+        if (value instanceof Scalar scalar) {
+            if (!scalar.isValid()) {
+                this.valid = false;
+                this.value = false;
+                return;
+            }
+
+            this.set(scalar.get());
+            return;
+        }
+
+        if (value instanceof Boolean b) {
+            this.valid = true;
+            this.value = b;
+            return;
+        }
+
+        if (value instanceof String string) {
+            this.valid = true;
+            this.value = Boolean.parseBoolean(string);
+            return;
+        }
+
+        throw new ValidationException(ValidationException.NO_CONVERSION_AVAILABLE, this.dataType(), value);
+    }
+
+    @Override
+    public Object get() {
+        if (this.valid) {
+            return this.value;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+
+        if (!(other instanceof Bool o)) {
+            return false;
+        }
+
+        return (this.valid == o.valid) && (this.value == o.value);
+    }
+}

--- a/lib/src/test/java/io/cloudquery/scalar/BinaryTest.java
+++ b/lib/src/test/java/io/cloudquery/scalar/BinaryTest.java
@@ -1,13 +1,7 @@
 package io.cloudquery.scalar;
 
-import io.cloudquery.scalar.Binary;
-import io.cloudquery.scalar.ValidationException;
-
 import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -139,7 +133,7 @@ public class BinaryTest {
         Binary b = new Binary();
         assertEquals(a, b);
         assertNotEquals(a, null);
-        assertEquals(a, new LargeBinary()); // we can cast LargeBinary to Binary
+        assertNotEquals(a, new Bool()); // we can't cast Bool to Binary
         assertNotEquals(null, a);
 
         assertDoesNotThrow(() -> {

--- a/lib/src/test/java/io/cloudquery/scalar/BoolTest.java
+++ b/lib/src/test/java/io/cloudquery/scalar/BoolTest.java
@@ -1,0 +1,129 @@
+package io.cloudquery.scalar;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class BoolTest {
+    @Test
+    public void testNew() {
+        assertDoesNotThrow(() -> {
+            new Bool();
+        });
+    }
+
+    @Test
+    public void testNewWithValidParam() {
+        assertDoesNotThrow(() -> {
+            new Bool(true);
+            new Bool("true");
+
+            Scalar s = new Bool(true);
+            new Bool(s);
+        });
+    }
+
+    @Test
+    public void testNewWithInvalidParam() {
+        assertThrows(ValidationException.class, () -> {
+            new Bool(new char[]{'1'});
+        });
+    }
+
+    @Test
+    public void testToString() {
+        Bool b = new Bool();
+        assertEquals(Scalar.NULL_VALUE_STRING, b.toString());
+
+        assertDoesNotThrow(() -> {
+            b.set(true);
+        });
+        assertEquals("true", b.toString());
+
+        assertDoesNotThrow(() -> {
+            b.set(false);
+        });
+        assertEquals("false", b.toString());
+    }
+
+    @Test
+    public void testDataType() {
+        Bool b = new Bool();
+        assertEquals(ArrowType.Bool.INSTANCE, b.dataType());
+        assertEquals(new ArrowType.Bool(), b.dataType());
+    }
+
+    @Test
+    public void testIsValid() {
+        Bool b = new Bool();
+        assertFalse(b.isValid());
+
+        assertDoesNotThrow(() -> {
+            b.set("true");
+        });
+        assertTrue(b.isValid());
+    }
+
+    @Test
+    public void testSet() {
+        Bool b = new Bool();
+        assertDoesNotThrow(() -> {
+            new Bool(true);
+            new Bool("true");
+
+            Scalar s = new Bool(true);
+            b.set(s);
+        });
+    }
+
+    @Test
+    public void testSetWithInvalidParam() {
+        Bool b = new Bool();
+        assertThrows(ValidationException.class, () -> {
+            b.set(new char[]{});
+        });
+    }
+
+    @Test
+    public void testGet() {
+        Bool b = new Bool();
+        assertFalse(b.isValid());
+        assertNull(b.get());
+
+        assertDoesNotThrow(() -> {
+            b.set(true);
+        });
+        assertTrue(b.isValid());
+        assertEquals(true, b.get());
+
+        assertDoesNotThrow(() -> {
+            b.set("abc");
+        });
+        assertTrue(b.isValid());
+        assertEquals(false, b.get());
+    }
+
+    @Test
+    public void testEquals() {
+        Bool a = new Bool();
+        Bool b = new Bool();
+        assertEquals(a, b);
+        assertNotEquals(a, null);
+        assertNotEquals(a, new Binary()); // we can't cast Binary to Bool
+        assertNotEquals(null, a);
+
+        assertDoesNotThrow(() -> {
+            a.set(true);
+        });
+        assertNotEquals(a, b);
+
+        assertDoesNotThrow(() -> {
+            for (Object obj : new Object[]{null, true, false, "abc", "true", "false"}) {
+                a.set(obj);
+                assertEquals(a, new Bool(obj));
+            }
+        });
+    }
+}

--- a/lib/src/test/java/io/cloudquery/scalar/LargeBinaryTest.java
+++ b/lib/src/test/java/io/cloudquery/scalar/LargeBinaryTest.java
@@ -126,22 +126,23 @@ public class LargeBinaryTest {
         assertTrue(b.isValid());
         assertArrayEquals(new byte[]{'a', 'b', 'c'}, (byte[]) b.get());
     }
+
     @Test
     public void testEquals() {
         LargeBinary a = new LargeBinary();
         LargeBinary b = new LargeBinary();
         assertEquals(a, b);
-        assertNotEquals(a,null);
-        assertNotEquals(a,new Binary()); // we can't cast Binary to LargeBinary
+        assertNotEquals(a, null);
+        assertNotEquals(a, new Bool()); // we can't cast Bool to LargeBinary
         assertNotEquals(null, a);
 
         assertDoesNotThrow(() -> {
             a.set(new byte[]{'a', 'b', 'c'});
         });
-        assertNotEquals(a,b);
+        assertNotEquals(a, b);
 
         assertDoesNotThrow(() -> {
-            for (Object obj: new Object[]{
+            for (Object obj : new Object[]{
                     null,
                     new byte[]{'a', 'b', 'c'},
                     new char[]{'a', 'b', 'c'},


### PR DESCRIPTION
Closes #26