### PR TITLE
chore: adding type transformer

### DIFF
--- a/lib/src/main/java/io/cloudquery/transformers/NameTransformer.java
+++ b/lib/src/main/java/io/cloudquery/transformers/NameTransformer.java
@@ -3,7 +3,6 @@ package io.cloudquery.transformers;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.cloudquery.caser.Caser;
 
-import javax.xml.transform.TransformerException;
 import java.lang.reflect.Field;
 
 public interface NameTransformer {
@@ -16,10 +15,9 @@ public interface NameTransformer {
          *
          * @param field Field to transform
          * @return Transformed field name
-         * @throws TransformerException If the field name cannot be transformed
          */
         @Override
-        public String transform(Field field) throws TransformerException {
+        public String transform(Field field) {
             JsonProperty annotation = field.getAnnotation(JsonProperty.class);
             if (annotation != null) {
                 return annotation.value();

--- a/lib/src/main/java/io/cloudquery/transformers/TransformerException.java
+++ b/lib/src/main/java/io/cloudquery/transformers/TransformerException.java
@@ -1,0 +1,7 @@
+package io.cloudquery.transformers;
+
+public class TransformerException extends Exception{
+    public TransformerException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/io/cloudquery/transformers/TypeTransformer.java
+++ b/lib/src/main/java/io/cloudquery/transformers/TypeTransformer.java
@@ -1,0 +1,60 @@
+package io.cloudquery.transformers;
+
+import io.cloudquery.types.InetType;
+import io.cloudquery.types.JSONType;
+import io.cloudquery.types.ListType;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.lang.reflect.Field;
+
+public interface TypeTransformer {
+    class DefaultTypeTransformer implements TypeTransformer {
+        @Override
+        public ArrowType transform(Field field) throws TransformerException {
+            return transformArrowType(field.getName(), field.getType());
+        }
+
+        private static ArrowType transformArrowType(String name, Class<?> type) throws TransformerException {
+            switch (type.getName()) {
+                case "java.lang.String" -> {
+                    return ArrowType.Utf8.INSTANCE;
+                }
+                case "java.lang.Boolean", "boolean" -> {
+                    return ArrowType.Bool.INSTANCE;
+                }
+                case "java.lang.Integer", "int", "java.lang.Long", "long" -> {
+                    return new ArrowType.Int(64, true);
+                }
+                case "float", "double", "java.lang.Float", "java.lang.Double" -> {
+                    return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+                }
+                case "java.util.Map" -> {
+                    return JSONType.INSTANCE;
+                }
+                case "java.net.InetAddress" -> {
+                    return InetType.INSTANCE;
+                }
+                case "java.time.LocalDateTime" -> {
+                    return new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+                }
+                default -> {
+                    if (type.isArray()) {
+                        Class<?> componentType = type.getComponentType();
+                        if (componentType.getName().equals("byte")) {
+                            return ArrowType.Binary.INSTANCE;
+                        }
+                        return ListType.listOf(transformArrowType(name, componentType));
+                    }
+                    if (!type.isPrimitive()) {
+                        return JSONType.INSTANCE;
+                    }
+                }
+            }
+            throw new TransformerException("Unsupported type: " + type.getName() + " for field: " + name);
+        }
+    }
+
+    ArrowType transform(Field field) throws TransformerException;
+}

--- a/lib/src/main/java/io/cloudquery/types/InetType.java
+++ b/lib/src/main/java/io/cloudquery/types/InetType.java
@@ -1,0 +1,42 @@
+package io.cloudquery.types;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+public class InetType extends ArrowType.ExtensionType {
+    public static final InetType INSTANCE = new InetType();
+
+    @Override
+    public ArrowType storageType() {
+        return Binary.INSTANCE;
+    }
+
+    @Override
+    public String extensionName() {
+        return "inet";
+    }
+
+    @Override
+    public boolean extensionEquals(ExtensionType other) {
+        if (!(other instanceof InetType))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String serialize() {
+        return null;
+    }
+
+    @Override
+    public ArrowType deserialize(ArrowType storageType, String serializedData) {
+        return null;
+    }
+
+    @Override
+    public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator) {
+        return null;
+    }
+}

--- a/lib/src/main/java/io/cloudquery/types/JSONType.java
+++ b/lib/src/main/java/io/cloudquery/types/JSONType.java
@@ -1,0 +1,54 @@
+package io.cloudquery.types;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+public class JSONType extends ExtensionType {
+    public static final JSONType INSTANCE = new JSONType();
+
+    @Override
+    public ArrowType storageType() {
+        return ArrowType.Binary.INSTANCE;
+    }
+
+    @Override
+    public String extensionName() {
+        return "json";
+    }
+
+    @Override
+    public boolean extensionEquals(ExtensionType other) {
+        return false;
+    }
+
+    @Override
+    public String serialize() {
+        return null;
+    }
+
+    @Override
+    public ArrowType deserialize(ArrowType storageType, String serializedData) {
+        return null;
+    }
+
+    @Override
+    public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator) {
+        return null;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Arrays.deepHashCode(new Object[]{});
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof JSONType)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/lib/src/main/java/io/cloudquery/types/ListType.java
+++ b/lib/src/main/java/io/cloudquery/types/ListType.java
@@ -1,0 +1,43 @@
+package io.cloudquery.types;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.Objects;
+
+public class ListType extends ArrowType.List {
+
+    public static ListType listOf(ArrowType elementType) {
+        return new ListType(elementType);
+    }
+
+    private final ArrowType elementType;
+
+    public ListType(ArrowType elementType) {
+        this.elementType = elementType;
+    }
+
+    public ArrowType getElementType() {
+        return elementType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ListType listType = (ListType) o;
+        return Objects.equals(elementType, listType.elementType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), elementType);
+    }
+
+    @Override
+    public String toString() {
+        return "ListType{" +
+                "elementType=" + elementType +
+                '}';
+    }
+}

--- a/lib/src/test/java/io/cloudquery/transformers/TypeTransformerTest.java
+++ b/lib/src/test/java/io/cloudquery/transformers/TypeTransformerTest.java
@@ -1,0 +1,110 @@
+package io.cloudquery.transformers;
+
+import io.cloudquery.transformers.TypeTransformer.DefaultTypeTransformer;
+import io.cloudquery.types.InetType;
+import io.cloudquery.types.JSONType;
+import io.cloudquery.types.ListType;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TypeTransformerTest {
+
+    @SuppressWarnings("unused")
+    private static class InnerClass {
+        private String innerClassStringField;
+    }
+
+    @SuppressWarnings("unused")
+    private static class SimpleClass {
+        private String stringField;
+
+        private boolean booleanField;
+        private Boolean booleanObjectField;
+
+        private int intField;
+        private Integer integerObjectField;
+        private long longField;
+        private Long longObjectField;
+
+        private float floatField;
+        private Float floatObjectField;
+        private double doubleField;
+        private Double doubleObjectField;
+
+        private Map<String, String> mapField;
+
+        private InnerClass innerClassObjectField;
+
+        private int[] intArrayField;
+        private String[] stringArrayField;
+
+        private LocalDateTime timeField;
+
+        private InetAddress inetField;
+
+        private byte[] byteArrayField;
+    }
+
+    @ParameterizedTest
+    @MethodSource("testArgumentsSource")
+    public void shouldTransformFields(String fieldName, ArrowType expectedArrowType) throws NoSuchFieldException, TransformerException {
+        DefaultTypeTransformer transfomer = new DefaultTypeTransformer();
+
+        ArrowType arrowType = transfomer.transform(SimpleClass.class.getDeclaredField(fieldName));
+
+        assertEquals(expectedArrowType, arrowType);
+    }
+
+    public static Stream<Arguments> testArgumentsSource() {
+        return Stream.of(
+                // Integer arguments
+                Arguments.of("intField", new ArrowType.Int(64, true)),
+                Arguments.of("integerObjectField", new ArrowType.Int(64, true)),
+                Arguments.of("longField", new ArrowType.Int(64, true)),
+                Arguments.of("longObjectField", new ArrowType.Int(64, true)),
+
+                // String arguments
+                Arguments.of("stringField", ArrowType.Utf8.INSTANCE),
+
+                // Boolean arguments
+                Arguments.of("booleanField", ArrowType.Bool.INSTANCE),
+                Arguments.of("booleanObjectField", ArrowType.Bool.INSTANCE),
+
+                // Float field
+                Arguments.of("floatField", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+                Arguments.of("floatObjectField", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+                Arguments.of("doubleField", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+                Arguments.of("doubleObjectField", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+
+                // Map field
+                Arguments.of("mapField", JSONType.INSTANCE),
+
+                // Inner class
+                Arguments.of("innerClassObjectField", JSONType.INSTANCE),
+
+                // Array field
+                Arguments.of("intArrayField", ListType.listOf(new ArrowType.Int(64, true))),
+                Arguments.of("stringArrayField", ListType.listOf(ArrowType.Utf8.INSTANCE)),
+
+                // Time
+                Arguments.of("timeField", new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)),
+
+                // Byte
+                Arguments.of("byteArrayField", ArrowType.Binary.INSTANCE),
+
+                // Inet
+                Arguments.of("inetField", InetType.INSTANCE)
+        );
+    }
+}

--- a/lib/src/test/java/io/cloudquery/types/ListTypeTest.java
+++ b/lib/src/test/java/io/cloudquery/types/ListTypeTest.java
@@ -1,0 +1,19 @@
+package io.cloudquery.types;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ListTypeTest {
+    @Test
+    public void testEquality() {
+        ListType listType1 = ListType.listOf(new ArrowType.Int(64, true));
+        ListType listType2 = ListType.listOf(new ArrowType.Int(64, true));
+        ListType listType3 = ListType.listOf(new ArrowType.Int(32, true));
+
+        assertEquals(listType1, listType2);
+        assertNotEquals(listType1, listType3);
+    }
+}


### PR DESCRIPTION
Implementing tests for a type converter to convert types in a similar way to the current [Go implementation](https://github.com/cloudquery/plugin-sdk/blob/main/transformers/struct_test.go#L22-L52). 

* Some simple stubbed Arrow extension types needed to be added for `InetType` and `JSONType` - implementation to follow in future PRs. 
* A wrapper around the arrow `List` type was created to reproduce the `ListOf` functionality present in the Go arrow SDK but not in the Java.


fixes: #31
