### PR TITLE
chore: adding a resolver transformer

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     testImplementation(platform('org.junit:junit-bom:5.10.0'))
     testImplementation('org.junit.jupiter:junit-jupiter:5.10.0')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.10.0')
+    testImplementation('org.mockito:mockito-core:5.4.0')
+    testImplementation('org.mockito:mockito-junit-jupiter:5.4.0')
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.10.0')
 
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/lib/src/main/java/io/cloudquery/schema/ClientMeta.java
+++ b/lib/src/main/java/io/cloudquery/schema/ClientMeta.java
@@ -1,0 +1,4 @@
+package io.cloudquery.schema;
+
+public class ClientMeta {
+}

--- a/lib/src/main/java/io/cloudquery/schema/Column.java
+++ b/lib/src/main/java/io/cloudquery/schema/Column.java
@@ -1,0 +1,10 @@
+package io.cloudquery.schema;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Column {
+    private String name;
+}

--- a/lib/src/main/java/io/cloudquery/schema/ColumnResolver.java
+++ b/lib/src/main/java/io/cloudquery/schema/ColumnResolver.java
@@ -1,0 +1,7 @@
+package io.cloudquery.schema;
+
+import io.cloudquery.transformers.TransformerException;
+
+public interface ColumnResolver {
+    void resolve(ClientMeta meta, Resource resource, Column column) throws TransformerException;
+}

--- a/lib/src/main/java/io/cloudquery/schema/Resource.java
+++ b/lib/src/main/java/io/cloudquery/schema/Resource.java
@@ -1,0 +1,14 @@
+package io.cloudquery.schema;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Resource {
+    private Object item;
+
+
+    public void set(String columnName, Object value) {
+    }
+}

--- a/lib/src/main/java/io/cloudquery/transformers/ResolverTransformer.java
+++ b/lib/src/main/java/io/cloudquery/transformers/ResolverTransformer.java
@@ -1,0 +1,24 @@
+package io.cloudquery.transformers;
+
+import io.cloudquery.helper.ReflectionPathResolver;
+import io.cloudquery.helper.ReflectionPathResolver.PathResolverException;
+import io.cloudquery.schema.ColumnResolver;
+
+import java.lang.reflect.Field;
+
+public interface ResolverTransformer {
+    class DefaulResolverTransformer implements ResolverTransformer {
+        @Override
+        public ColumnResolver transform(Field field, String path) throws TransformerException {
+            return (meta, resource, column) -> {
+                try {
+                    resource.set(column.getName(), ReflectionPathResolver.resolve(resource.getItem(), path));
+                } catch (PathResolverException ex) {
+                    throw new TransformerException("Failed to resolve path: " + path, ex);
+                }
+            };
+        }
+    }
+
+    ColumnResolver transform(Field field, String path) throws TransformerException;
+}

--- a/lib/src/main/java/io/cloudquery/transformers/TransformerException.java
+++ b/lib/src/main/java/io/cloudquery/transformers/TransformerException.java
@@ -1,7 +1,11 @@
 package io.cloudquery.transformers;
 
-public class TransformerException extends Exception{
+public class TransformerException extends Exception {
     public TransformerException(String message) {
         super(message);
+    }
+
+    public TransformerException(String message, Throwable ex) {
+        super(message, ex);
     }
 }

--- a/lib/src/test/java/io/cloudquery/transformers/DefaultResolverTransformerTest.java
+++ b/lib/src/test/java/io/cloudquery/transformers/DefaultResolverTransformerTest.java
@@ -1,0 +1,53 @@
+package io.cloudquery.transformers;
+
+import io.cloudquery.schema.Column;
+import io.cloudquery.schema.Resource;
+import io.cloudquery.transformers.ResolverTransformer.DefaulResolverTransformer;
+import lombok.Builder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultResolverTransformerTest {
+
+    @Builder
+    public static class ResourceItem {
+        public String myCustomID;
+    }
+
+    private DefaulResolverTransformer transformer;
+
+    @Mock
+    private Resource resource;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new DefaulResolverTransformer();
+
+        when(resource.getItem()).thenReturn(ResourceItem.builder().myCustomID("1234").build());
+    }
+
+    @Test
+    public void shouldTransformCustomFieldNamesFromResource() throws TransformerException {
+        Column targetColumn = Column.builder().name("id").build();
+
+        transformer.transform(null, "myCustomID").resolve(null, resource, targetColumn);
+
+        verify(resource).set(eq("id"), eq("1234"));
+    }
+
+    @Test
+    public void shouldThrowExceptionIfResourceFieldNameNotFound() throws TransformerException {
+        Column targetColumn = Column.builder().name("id").build();
+
+        assertThrows(TransformerException.class, () -> transformer.transform(null, "badFieldName").resolve(null, resource, targetColumn));
+    }
+}


### PR DESCRIPTION
Adding the default implementation for the `ResolverTransformer` to set the value of a scalar based on a path lookup in the base resource item.

fixes: #32
