### PR TITLE
fix: Pass options to tables method

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "io.grpc:grpc-stub:1.57.1"
     implementation "io.grpc:grpc-services:1.57.1"
     implementation "io.grpc:grpc-testing:1.57.1"
-    implementation "io.cloudquery:plugin-pb-java:0.0.5"
+    implementation "io.cloudquery:plugin-pb-java:0.0.6"
     implementation "org.apache.arrow:arrow-memory-core:12.0.1"
     implementation "org.apache.arrow:arrow-vector:12.0.1"
 

--- a/lib/src/main/java/io/cloudquery/internal/servers/plugin/v3/PluginServer.java
+++ b/lib/src/main/java/io/cloudquery/internal/servers/plugin/v3/PluginServer.java
@@ -57,7 +57,11 @@ public class PluginServer extends PluginImplBase {
       io.cloudquery.plugin.v3.GetTables.Request request,
       StreamObserver<io.cloudquery.plugin.v3.GetTables.Response> responseObserver) {
     try {
-      List<Table> tables = plugin.tables();
+      List<Table> tables =
+          plugin.tables(
+              request.getTablesList(),
+              request.getSkipTablesList(),
+              request.getSkipDependentTables());
       List<ByteString> byteStrings = new ArrayList<>();
       for (Table table : tables) {
         try (BufferAllocator bufferAllocator = new RootAllocator()) {

--- a/lib/src/main/java/io/cloudquery/memdb/MemDB.java
+++ b/lib/src/main/java/io/cloudquery/memdb/MemDB.java
@@ -29,8 +29,10 @@ public class MemDB extends Plugin {
   }
 
   @Override
-  public List<Table> tables() throws SchemaException {
-    return Table.filterDFS(allTables, List.of("*"), List.of(), false);
+  public List<Table> tables(
+      List<String> includeList, List<String> skipList, boolean skipDependentTables)
+      throws SchemaException {
+    return Table.filterDFS(allTables, includeList, skipList, skipDependentTables);
   }
 
   @Override

--- a/lib/src/main/java/io/cloudquery/plugin/Plugin.java
+++ b/lib/src/main/java/io/cloudquery/plugin/Plugin.java
@@ -18,7 +18,9 @@ public abstract class Plugin {
 
   public abstract void init();
 
-  public abstract List<Table> tables() throws SchemaException;
+  public abstract List<Table> tables(
+      List<String> includeList, List<String> skipList, boolean skipDependentTables)
+      throws SchemaException;
 
   public abstract void sync();
 


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/plugin-sdk-java/pull/71.

Passes the options so users can filter tables