### PR TITLE
fix: Flatten tables in getTables gRPC call

### DIFF
--- a/lib/src/main/java/io/cloudquery/internal/servers/plugin/v3/PluginServer.java
+++ b/lib/src/main/java/io/cloudquery/internal/servers/plugin/v3/PluginServer.java
@@ -63,7 +63,7 @@ public class PluginServer extends PluginImplBase {
               request.getSkipTablesList(),
               request.getSkipDependentTables());
       List<ByteString> byteStrings = new ArrayList<>();
-      for (Table table : tables) {
+      for (Table table : Table.flattenTables(tables)) {
         try (BufferAllocator bufferAllocator = new RootAllocator()) {
           Schema schema = table.toArrowSchema();
           VectorSchemaRoot schemaRoot = VectorSchemaRoot.create(schema, bufferAllocator);


### PR DESCRIPTION
We need to flatten tables in the `getTables` call otherwise relations will not be migrated in `cloudquery migrate` (see https://github.com/cloudquery/plugin-sdk-python/pull/41)