### PR TITLE
fix: Add `jackson-annotations` to `build.gradle`

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "org.apache.arrow:arrow-vector:12.0.1"
 
     implementation "com.fasterxml.jackson.core:jackson-core:2.15.1"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.15.1"
 
     implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'


### PR DESCRIPTION
I removed this by mistake in https://github.com/cloudquery/plugin-sdk-java/pull/82