### PR TITLE
fix: make the underlying timestamp consistent

### DIFF
--- a/lib/src/main/java/io/cloudquery/scalar/Timestamp.java
+++ b/lib/src/main/java/io/cloudquery/scalar/Timestamp.java
@@ -1,6 +1,11 @@
 package io.cloudquery.scalar;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
@@ -8,7 +13,8 @@ public class Timestamp extends Scalar<Long> {
   public static final ZoneId zoneID = ZoneOffset.UTC;
 
   // TODO: add more units support later
-  private static final ArrowType dt = new ArrowType.Timestamp(TimeUnit.SECOND, zoneID.toString());
+  private static final ArrowType dt =
+      new ArrowType.Timestamp(TimeUnit.MILLISECOND, zoneID.toString());
 
   public Timestamp() {
     super();
@@ -26,34 +32,36 @@ public class Timestamp extends Scalar<Long> {
   @Override
   public void setValue(Object value) throws ValidationException {
     if (value instanceof ZonedDateTime timestamp) {
-      this.value = timestamp.withZoneSameInstant(zoneID).toEpochSecond();
+      this.value = timestamp.withZoneSameInstant(zoneID).toEpochSecond() * 1000;
       return;
     }
 
     if (value instanceof LocalDate date) {
-      this.value = date.atStartOfDay(zoneID).toEpochSecond();
+      this.value = date.atStartOfDay(zoneID).toEpochSecond() * 1000;
       return;
     }
 
     if (value instanceof LocalDateTime date) {
-      this.value = date.atZone(zoneID).toEpochSecond();
+      this.value = date.atZone(zoneID).toEpochSecond() * 1000;
       return;
     }
 
     if (value instanceof Integer integer) {
       this.value =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(integer), ZoneOffset.UTC).toEpochSecond();
+          ZonedDateTime.ofInstant(Instant.ofEpochMilli(integer), ZoneOffset.UTC).toEpochSecond()
+              * 1000;
       return;
     }
 
     if (value instanceof Long longValue) {
       this.value =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(longValue), ZoneOffset.UTC).toEpochSecond();
+          ZonedDateTime.ofInstant(Instant.ofEpochMilli(longValue), ZoneOffset.UTC).toEpochSecond()
+              * 1000;
       return;
     }
 
     if (value instanceof CharSequence sequence) {
-      this.value = ZonedDateTime.parse(sequence).toEpochSecond();
+      this.value = ZonedDateTime.parse(sequence).toInstant().toEpochMilli();
       return;
     }
 
@@ -64,7 +72,7 @@ public class Timestamp extends Scalar<Long> {
   @Override
   public java.lang.String toString() {
     if (this.value != null) {
-      return ZonedDateTime.ofInstant(Instant.ofEpochSecond((Long) this.value), zoneID).toString();
+      return ZonedDateTime.ofInstant(Instant.ofEpochMilli((Long) this.value), zoneID).toString();
     }
 
     return NULL_VALUE_STRING;

--- a/lib/src/test/java/io/cloudquery/scalar/TimestampTest.java
+++ b/lib/src/test/java/io/cloudquery/scalar/TimestampTest.java
@@ -1,6 +1,12 @@
 package io.cloudquery.scalar;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -66,7 +72,7 @@ public class TimestampTest {
   @Test
   public void testDataType() {
     Timestamp timestamp = new Timestamp();
-    assertEquals(new ArrowType.Timestamp(TimeUnit.SECOND, "Z"), timestamp.dataType());
+    assertEquals(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "Z"), timestamp.dataType());
   }
 
   @Test
@@ -118,7 +124,7 @@ public class TimestampTest {
           timestamp.set(ts);
         });
     assertTrue(timestamp.isValid());
-    assertEquals(ts.toEpochSecond(), timestamp.get());
+    assertEquals(ts.toEpochSecond() * 1000, timestamp.get());
 
     assertDoesNotThrow(
         () -> {


### PR DESCRIPTION
Switch to using a base storage of `ms` and consistent across all parsing methods
