### PR TITLE
fix: Use correct param name for `--no-sentry` (not `--disable-sentry`)

### DIFF
--- a/lib/src/main/java/io/cloudquery/server/ServeCommand.java
+++ b/lib/src/main/java/io/cloudquery/server/ServeCommand.java
@@ -55,7 +55,7 @@ public class ServeCommand implements Callable<Integer> {
           "the network must be \"tcp\", \"tcp4\", \"tcp6\", \"unix\" or \"unixpacket\" (default \"${DEFAULT-VALUE}\")")
   private String network = "tcp";
 
-  @Option(names = "--disable-sentry", description = "disable sentry")
+  @Option(names = "--no-sentry", description = "disable sentry")
   private Boolean disableSentry = false;
 
   @Option(names = "--otel-endpoint", description = "Open Telemetry HTTP collector endpoint")

--- a/lib/src/test/java/io/cloudquery/server/PluginServeTest.java
+++ b/lib/src/test/java/io/cloudquery/server/PluginServeTest.java
@@ -39,7 +39,7 @@ public class PluginServeTest {
           "serve",
           "--address",
           "foo.bar.com:7777",
-          "--disable-sentry",
+          "--no-sentry",
           "--otel-endpoint",
           "some-endpoint"
         };


### PR DESCRIPTION
Otherwise plugins can't seem to be launched

https://github.com/cloudquery/plugin-pb-go/blob/cd22fa7ec57df5d7d1f5b3991d4910df8df93696/managedplugin/plugin.go#L388