### PR TITLE
fix: Add --license placeholder for future use

### DIFF
--- a/lib/src/main/java/io/cloudquery/server/ServeCommand.java
+++ b/lib/src/main/java/io/cloudquery/server/ServeCommand.java
@@ -66,7 +66,9 @@ public class ServeCommand implements Callable<Integer> {
       description = "use Open Telemetry HTTP endpoint (for development only)")
   private Boolean otelEndpointInsecure = false;
 
-  @Option(names = "--license", description = "set offline license file (placeholder for future use)")
+  @Option(
+      names = "--license",
+      description = "set offline license file (placeholder for future use)")
   private String licenseFile = "";
 
   private final Plugin plugin;

--- a/lib/src/main/java/io/cloudquery/server/ServeCommand.java
+++ b/lib/src/main/java/io/cloudquery/server/ServeCommand.java
@@ -66,6 +66,9 @@ public class ServeCommand implements Callable<Integer> {
       description = "use Open Telemetry HTTP endpoint (for development only)")
   private Boolean otelEndpointInsecure = false;
 
+  @Option(names = "--license", description = "set offline license file (placeholder for future use)")
+  private String licenseFile = "";
+
   private final Plugin plugin;
 
   public ServeCommand(Plugin plugin) {


### PR DESCRIPTION
plugin-pb-go [1.15.0](https://github.com/cloudquery/plugin-pb-go/pull/196) now uses `--license` when invoking plugins, if one is set by the cli.