### PR TITLE
fix: Add missing docker_image_tag in package json

### DIFF
--- a/lib/src/main/java/io/cloudquery/server/PackageCommand.java
+++ b/lib/src/main/java/io/cloudquery/server/PackageCommand.java
@@ -260,7 +260,8 @@ public class PackageCommand implements Callable<Integer> {
       runCommand(dockerSaveArguments);
       try (InputStream is = Files.newInputStream(Paths.get(imagePath))) {
         String checksum = DigestUtils.sha256Hex(is);
-        SupportedTargetJson supportedTarget = new SupportedTargetJson(os, arch, imageTar, checksum);
+        SupportedTargetJson supportedTarget =
+            new SupportedTargetJson(os, arch, imageTar, checksum, imageTag);
         supportedTargets.add(supportedTarget);
       }
     }

--- a/lib/src/main/java/io/cloudquery/server/SupportedTargetJson.java
+++ b/lib/src/main/java/io/cloudquery/server/SupportedTargetJson.java
@@ -11,4 +11,5 @@ public class SupportedTargetJson {
   @NonNull private final String arch;
   @NonNull private final String path;
   @NonNull private final String checksum;
+  @NonNull private final String docker_image_tag;
 }


### PR DESCRIPTION
Forgot this in https://github.com/cloudquery/plugin-sdk-java/pull/194