### PR TITLE
fix: Call setParents on `MemDB` tables

### DIFF
--- a/lib/src/main/java/io/cloudquery/memdb/MemDB.java
+++ b/lib/src/main/java/io/cloudquery/memdb/MemDB.java
@@ -23,64 +23,71 @@ import java.util.UUID;
 
 public class MemDB extends Plugin {
   private static List<Table> getTables() {
-    return List.of(
-        Table.builder()
-            .name("table1")
-            .resolver(
-                new TableResolver() {
-                  @Override
-                  public void resolve(
-                      ClientMeta clientMeta, Resource parent, TableOutputStream stream) {
-                    stream.write(
-                        Table1Data.builder()
-                            .id(UUID.fromString("46b2b6e6-8f3e-4340-a721-4aa0786b1cc0"))
-                            .name("name1")
-                            .timestamp(LocalDateTime.now())
-                            .json(Map.of("key1", "value1", "key2", "value2"))
-                            .build());
-                    stream.write(
-                        Table1Data.builder()
-                            .id(UUID.fromString("e89f95df-a389-4f1b-9ba6-1fab565523d6"))
-                            .name("name2")
-                            .build());
-                  }
-                })
-            .transform(TransformWithClass.builder(Table1Data.class).pkField("id").build())
-            .build(),
-        Table.builder()
-            .name("table2")
-            .resolver(
-                new TableResolver() {
-                  @Override
-                  public void resolve(
-                      ClientMeta clientMeta, Resource parent, TableOutputStream stream) {
-                    stream.write(Table2Data.builder().id(1).name("name1").build());
-                    stream.write(Table2Data.builder().id(2).name("name2").build());
-                  }
-                })
-            .transform(TransformWithClass.builder(Table2Data.class).pkField("id").build())
-            .relations(
-                List.of(
-                    Table.builder()
-                        .name("table2_child")
-                        .resolver(
-                            new TableResolver() {
+    List<Table> tables =
+        List.of(
+            Table.builder()
+                .name("table1")
+                .resolver(
+                    new TableResolver() {
+                      @Override
+                      public void resolve(
+                          ClientMeta clientMeta, Resource parent, TableOutputStream stream) {
+                        stream.write(
+                            Table1Data.builder()
+                                .id(UUID.fromString("46b2b6e6-8f3e-4340-a721-4aa0786b1cc0"))
+                                .name("name1")
+                                .timestamp(LocalDateTime.now())
+                                .json(Map.of("key1", "value1", "key2", "value2"))
+                                .build());
+                        stream.write(
+                            Table1Data.builder()
+                                .id(UUID.fromString("e89f95df-a389-4f1b-9ba6-1fab565523d6"))
+                                .name("name2")
+                                .build());
+                      }
+                    })
+                .transform(TransformWithClass.builder(Table1Data.class).pkField("id").build())
+                .build(),
+            Table.builder()
+                .name("table2")
+                .resolver(
+                    new TableResolver() {
+                      @Override
+                      public void resolve(
+                          ClientMeta clientMeta, Resource parent, TableOutputStream stream) {
+                        stream.write(Table2Data.builder().id(1).name("name1").build());
+                        stream.write(Table2Data.builder().id(2).name("name2").build());
+                      }
+                    })
+                .transform(TransformWithClass.builder(Table2Data.class).pkField("id").build())
+                .relations(
+                    List.of(
+                        Table.builder()
+                            .name("table2_child")
+                            .resolver(
+                                new TableResolver() {
 
-                              @Override
-                              public void resolve(
-                                  ClientMeta clientMeta,
-                                  Resource parent,
-                                  TableOutputStream stream) {
-                                String parentName = parent.get("name").toString();
-                                stream.write(
-                                    Table2ChildData.builder().name(parentName + "_name1").build());
-                                stream.write(
-                                    Table2ChildData.builder().name(parentName + "_name2").build());
-                              }
-                            })
-                        .transform(TransformWithClass.builder(Table2ChildData.class).build())
-                        .build()))
-            .build());
+                                  @Override
+                                  public void resolve(
+                                      ClientMeta clientMeta,
+                                      Resource parent,
+                                      TableOutputStream stream) {
+                                    String parentName = parent.get("name").toString();
+                                    stream.write(
+                                        Table2ChildData.builder()
+                                            .name(parentName + "_name1")
+                                            .build());
+                                    stream.write(
+                                        Table2ChildData.builder()
+                                            .name(parentName + "_name2")
+                                            .build());
+                                  }
+                                })
+                            .transform(TransformWithClass.builder(Table2ChildData.class).build())
+                            .build()))
+                .build());
+    Tables.setParents(tables, null);
+    return tables;
   }
 
   private List<Table> allTables;


### PR DESCRIPTION
I noticed the [table list for Bitbucket plugin is broken in the Hub](https://hub.cloudquery.io/plugins/source/cloudquery/bitbucket/latest/tables). The reason is that we don't call `setParents` thus publish all tables as top level ones. The UI then tries to render items with duplicate keys and fails.

This PR fixes the MemDB plugin in the SDK which is used as a reference for other plugins. I'll fix the Bitbucket plugin in a separate PR.

There might be a better way to implicitly initialize the parents but I don't we should spend more time on it