### PR TITLE
chore: Switch to `googleapis/release-please-action`

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GH_CQ_BOT }}


### PR DESCRIPTION
Part of https://github.com/cloudquery/cloudquery-issues/issues/1985 (internal issue).
`google-github-actions/release-please-action` was archived and moved to `googleapis/release-please-action`