### PR TITLE
chore: Use non deprecated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
+        # v4.4.1
+        uses: gradle/actions/wrapper-validation@ac638b010cf58a27ee6c972d7336334ccaf61c96
       - name: Build package
         run: ./gradlew build
         env:


### PR DESCRIPTION
The action we were using is deprecated https://github.com/gradle/wrapper-validation-action