### PR TITLE
chore(ci): Replace GH_CQ_BOT PAT with GitHub App tokens

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [approve]
-auto_approve_usernames = ["cq-bot"]
+auto_approve_usernames = ["cloudquery-ci"]
 
 [merge.message]
 body = "pull_request_body"

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -11,7 +11,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CQ_APP_ID }}
+          private-key: ${{ secrets.CQ_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
-          token: ${{ secrets.GH_CQ_BOT }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Replace GH_CQ_BOT PAT with short-lived tokens from the cloudquery-ci GitHub App.